### PR TITLE
Add the instructions for retrieving already activated packages from private account licenses steam site

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The regularly updated database contains more than 15,000 packages that will be a
 **Why it take so long to complete the script?**
 
 The Steam API has limitation for only 50 packages activation per one hour.
+
+Have a look into these [instructions](docs/instructions-for-users-with-many-packages.md) if you do already own many steam packages.
  
 **Why not all available packages will be registered to you account?**
 

--- a/docs/instructions-for-users-with-many-packages.md
+++ b/docs/instructions-for-users-with-many-packages.md
@@ -1,0 +1,28 @@
+#### These instructions do _only_ improve the performance of the script significantally if you own over 100 steam packages.
+
+1. Execute `activate_packages` for the 1st time
+2. Copy script to Clipboard
+```js
+var elements = document.querySelectorAll(
+    "div[class='free_license_remove_link'] > a"
+);
+var games = "";
+for (let i = 0; i < elements.length; i++) {
+    var game = elements[i].href;
+    game = game.match(/([1-9])\w+/g)[0];
+    games += game + ",";
+}
+console.log(games);
+```
+3. Open your [licenses and product key activations](https://store.steampowered.com/account/licenses/) page
+4. Open developer tools in your browser, [read more here](https://webmasters.stackexchange.com/questions/8525/how-do-i-open-the-javascript-console-in-different-browsers/77337#77337)
+5. Paste script (which is in your clipboard) into the console
+6. Copy the console output, which should look something like this:
+```
+430369,370157,367877,452385,122355,662406,
+```
+8. Open the `activated_packages.txt` file in a text editor
+9. Delete the existing file content
+10. Paste console output (which is in your clipboard) into the file
+11. Save the file
+12. Execute `activate_packages` to activate packages


### PR DESCRIPTION
Add the instructions for retrieving already activated packages from private account licenses steam site, which were discussed in #5 