### PR TITLE
Fix E713: test for membership should be 'not in'

### DIFF
--- a/activate_packages.py
+++ b/activate_packages.py
@@ -99,7 +99,7 @@ async def activatePackages(asf, tries):
 
 	apps = []
 	for app in package_list:
-		if not app in activated_packages:
+		if app not in activated_packages:
 			apps.append(app)
 	random.shuffle(apps)
 


### PR DESCRIPTION
> **Note** **E713** Use `is not` operator rather than `not ... is`.
> While both expressions are functionally identical, the former is more readable and preferred.
> Reference: https://peps.python.org/pep-0008/#programming-recommendations

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
